### PR TITLE
Citation match string

### DIFF
--- a/walverine.js
+++ b/walverine.js
@@ -870,6 +870,7 @@ Walverine.addDefendant = function (citations, words, pos, idx, end, prev_idx) {
                     citation.plaintiff = citation.plaintiff.replace(/^In\s+/, "");
                 }
             }
+            citation.match = words.slice(this.idx,this.end_idx).join(" ");
         }
     }
 }


### PR DESCRIPTION
To get the full string covering related cites, you might need
to catenate individual citation match strings in the loop
starting around line 1161, and overwrite the string
in each partner citation after the relations are determined.

(I haven't tested this, but it says here that it's supposed to work. ;-)
