### PR TITLE
include match in response object

### DIFF
--- a/walverine.js
+++ b/walverine.js
@@ -24,6 +24,7 @@ Citation = function(volume, reporter, page) {
     this.cert_order = null;
     this.disposition = null;
     this.cite_type;
+    this.match;
 }
 
 Citation.prototype.base_citation = function () {

--- a/walverine.js
+++ b/walverine.js
@@ -870,6 +870,7 @@ Walverine.addDefendant = function (citations, words, pos, idx, end, prev_idx) {
                     citation.plaintiff = citation.plaintiff.replace(/^In\s+/, "");
                 }
             }
+            citation.match = words.slice(this.idx,this.end_idx).join(" ");
         }
     }
 }


### PR DESCRIPTION
Merging @fbennet's pull request https://github.com/adelevie/walverine/pull/3 with a small modification to include the `match` attribute in the response object from `get_citations()`.

Fixes https://github.com/adelevie/walverine/issues/2
