### PR TITLE
Remove underscore as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.6",
   "description": "Extract case law citations from plain text",
   "main": "walverine.js",
-  "scripts": { 
+  "scripts": {
     "test": "nodeunit test"
   },
   "repository": {
@@ -19,11 +19,9 @@
     "url": "https://github.com/adelevie/walverine/issues"
   },
   "dependencies": {
-    "underscore": "*"
   },
    "devDependencies": {
     "nodeunit": "*",
-    "underscore": "*",
     "deep-equal": "*"
  }
 }

--- a/test/main.js
+++ b/test/main.js
@@ -1,14 +1,13 @@
 var test = require('nodeunit');
 var deepEqual = require('deep-equal');
-var _ = require('underscore');
 var walverine = require('../walverine');
 
 var singles = [
   {
     name: "Hardibble",
     text: "I am a cat. Smith v. Hardibble, 111 Cal.2d 222, 555, 558, 333 Cal.3d 444 (1988)",
-    matches: [ 
-      { 
+    matches: [
+      {
         volume: 111,
         reporter: 'Cal. 2d',
         page: 222,
@@ -26,9 +25,9 @@ var singles = [
         disposition: null,
         match: 'Smith v. Hardibble, 111 Cal.2d 222, 555, 558, 333 Cal.3d 444 (1988)',
         seqID: 0,
-        relations: [ 0, 1 ] 
+        relations: [ 0, 1 ]
       },
-      { 
+      {
         volume: 333,
         reporter: 'Cal. 3d',
         page: 444,
@@ -47,15 +46,15 @@ var singles = [
         CARRY_FORWARD: true,
         match: '558, 333 Cal.3d 444 (1988)',
         seqID: 1,
-        relations: [ 0, 1 ] 
-      } 
+        relations: [ 0, 1 ]
+      }
     ]
   }, // end Hardribble
   {
     name: "US v. Mead",
     text: "The dissent is correct that United States v. Mead Corp., 533 U. S. 218 (2001), requires that",
-    matches: [ 
-      { 
+    matches: [
+      {
         volume: 533,
         reporter: 'U.S.',
         page: 218,
@@ -73,15 +72,15 @@ var singles = [
         disposition: null,
         match: 'United States v. Mead Corp., 533 U. S. 218 (2001), requires that',
         seqID: 0,
-        relations: [ 0 ] 
-      } 
+        relations: [ 0 ]
+      }
     ]
   }, // end US v. Mead
   {
     name: "Cellco Partnership v. FCC",
     text: "The false dichotomy between “jurisdictional” and “non-jurisdictional” agency interpretations may be no more than a bogeyman, but it is dangerous all the same. Like the Hound of the Baskervilles, it is conjured by those with greater quarry in sight: Make no mistake—the ultimate target here is Chevron itself. Savvy challengers of agency action would play the “jurisdictional” card in every case. See, e.g., Cellco Partnership v. FCC, 700 F. 3d 534, 541 (CADC 2012). Some judges would be deceived bythe specious, but scary-sounding, “jurisdictional”-“nonjurisdictional” line; others tempted by the prospect of making public policy by prescribing the meaning of am-biguous statutory commands. The effect would be to transfer any number of interpretive decisions—archetypal Chevron questions, about how best to construe an ambigu-ous term in light of competing policy interests—from the agencies that administer the statutes to federal courts.",
-    matches: [ 
-      { 
+    matches: [
+      {
         volume: 700,
         reporter: 'F.3d',
         page: 534,
@@ -99,8 +98,8 @@ var singles = [
         disposition: null,
         match: 'Cellco Partnership v. FCC, 700 F. 3d 534, 541 (CADC 2012). Some judges would be deceived bythe specious, but scary-sounding, “jurisdictional”-“nonjurisdictional” line; others tempted by the prospect of making public policy by prescribing the meaning of am-biguous statutory commands. The effect would be to transfer any number of interpretive decisions—archetypal Chevron questions, about how best to construe an ambigu-ous term in light of competing policy interests—from the agencies that administer the statutes to federal courts.',
         seqID: 0,
-        relations: [ 0 ] 
-      } 
+        relations: [ 0 ]
+      }
     ]
   } // end Cellco Partnership
 ];
@@ -114,4 +113,4 @@ var testSingle = function(single) {
   };
 };
 
-_.each(singles, testSingle);
+singles.forEach(testSingle);


### PR DESCRIPTION
This removes underscore as a dependency (in the main lib and in tests), and replaces the few methods it was using with tiny shims. Should work back to IE6 or 7, something like that. (Without the shims, it would work in only IE9+.)
